### PR TITLE
simplejson now part of Python (2.6+)

### DIFF
--- a/jpake/jpake.py
+++ b/jpake/jpake.py
@@ -248,7 +248,7 @@ class JPAKE:
         assert len(zkp["id"]) <= 0xffff
         s = "".join([hashbn(generator), hashbn(gr), hashbn(gx),
                      number_to_string(len(zkp["id"]), 2),
-                     str(zkp["id"]]))
+                     str(zkp["id"])])
         h = string_to_number(sha1(s).digest())
         gb = pow(generator, b, p)
         y = pow(gx, h, p)

--- a/jpake/jpake.py
+++ b/jpake/jpake.py
@@ -248,7 +248,7 @@ class JPAKE:
         assert len(zkp["id"]) <= 0xffff
         s = "".join([hashbn(generator), hashbn(gr), hashbn(gx),
                      number_to_string(len(zkp["id"]), 2),
-                     zkp["id"]])
+                     str(zkp["id"]]))
         h = string_to_number(sha1(s).digest())
         gb = pow(generator, b, p)
         y = pow(gx, h, p)

--- a/jpake/jpake.py
+++ b/jpake/jpake.py
@@ -1,7 +1,10 @@
 
 import os, binascii
 from hashlib import sha256, sha1
-import simplejson
+try:
+    import json
+except ImportError:
+    import simplejson as json
 
 
 class JPAKEError(Exception):
@@ -146,20 +149,20 @@ class JPAKE:
     instance data is sensitive: protect it better than you would the original
     password. An attacker who learns the instance state from both sides will
     be able to reconstruct the shared key. These functions return a
-    dictionary: you are responsible for invoking e.g. simplejson.dumps() to
+    dictionary: you are responsible for invoking e.g. json.dumps() to
     serialize it into a string that can be written to disk. For params_80,
     the serialized JSON is typically about 750 bytes after construction, 1300
     bytes after one(), and 1800 bytes after two().
 
      j = JPAKE(password)
      send(j.one())
-     open('save.json','w').write(simplejson.dumps(j.to_json()))
+     open('save.json','w').write(json.dumps(j.to_json()))
      ...
-     j = JPAKE.from_json(simplejson.loads(open('save.json').read()))
+     j = JPAKE.from_json(json.loads(open('save.json').read()))
      send(j.two(receive()))
-     open('save.json','w').write(simplejson.dumps(j.to_json()))
+     open('save.json','w').write(json.dumps(j.to_json()))
      ...
-     j = JPAKE.from_json(simplejson.loads(open('save.json').read()))
+     j = JPAKE.from_json(json.loads(open('save.json').read()))
      key = j.three(receive())
 
     The messages returned by one() and two() are small dictionaries, safe to
@@ -186,7 +189,7 @@ class JPAKE:
         if signerid is None:
             signerid = binascii.hexlify(self.entropy(16))
         self.signerid = signerid
-        assert simplejson.dumps(self.signerid) # must be printable
+        assert json.dumps(self.signerid) # must be printable
         self.params = params
         q = params.q
         if isinstance(password, (int,long)):

--- a/jpake/test_jpake.py
+++ b/jpake/test_jpake.py
@@ -3,7 +3,10 @@ import unittest
 from jpake import JPAKE, DuplicateSignerID, params_80, params_112, params_128
 from binascii import hexlify
 from hashlib import sha256
-import simplejson
+try:
+    import json
+except ImportError:
+    import simplejson as json
 
 class Basic(unittest.TestCase):
     def test_success(self):
@@ -124,8 +127,8 @@ class OtherEntropy(unittest.TestCase):
 
 class Serialize(unittest.TestCase):
     def replace(self, orig):
-        data = simplejson.dumps(orig.to_json())
-        return JPAKE.from_json(simplejson.loads(data))
+        data = json.dumps(orig.to_json())
+        return JPAKE.from_json(json.loads(data))
 
     def test_serialize(self):
         pw = "password"
@@ -145,10 +148,10 @@ class Packed(unittest.TestCase):
         jA,jB = JPAKE(pw, signerid="Alice"), JPAKE(pw, signerid="Bob")
         m1A,m1B = jA.one(), jB.one()
         m1Ap = jA.pack_one(m1A)
-        #print "m1:", len(simplejson.dumps(m1A)), len(m1Ap)
+        #print "m1:", len(json.dumps(m1A)), len(m1Ap)
         m2A,m2B = jA.two(m1B), jB.two(jB.unpack_one(m1Ap))
         m2Ap = jA.pack_two(m2A)
-        #print "m2:", len(simplejson.dumps(m2A)), len(m2Ap)
+        #print "m2:", len(json.dumps(m2A)), len(m2Ap)
         kA,kB = jA.three(m2B), jB.three(jB.unpack_two(m2Ap))
         self.failUnlessEqual(hexlify(kA), hexlify(kB))
         self.failUnlessEqual(len(kA), len(sha256().digest()))


### PR DESCRIPTION
Hey Brian,

thanks for Python implementation of J-PAKE. It's incredibly useful to us while testing our Objective C and JavaScript implementations (which I'm modeling closely on your implementation, btw). Here's a small fix to make it run out of box on Python 2.6+ without requiring simplejson to be installed (it now ships with Python as the 'json' module).

Cheers
Philipp
